### PR TITLE
Add userToken for slack integration

### DIFF
--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -7,5 +7,6 @@ type: Opaque
 stringData:
   credentials: |
     {
-      "token": "y0ur-t0k3n"
+      "token": "y0ur-t0k3n",
+      "user_token": "y0ur-t0k3n"
     }

--- a/internal/clients/pagerduty.go
+++ b/internal/clients/pagerduty.go
@@ -26,6 +26,7 @@ const (
 	errExtractCredentials   = "cannot extract credentials"
 	errUnmarshalCredentials = "cannot unmarshal pagerduty credentials as JSON"
 	keyToken                = "token"
+	userToken               = "user_token"
 )
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
@@ -68,6 +69,10 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 
 		if v, ok := creds[keyToken]; ok {
 			ps.Configuration[keyToken] = v
+		}
+
+		if v, ok := creds[userToken]; ok {
+			ps.Configuration[userToken] = v
 		}
 
 		return ps, nil


### PR DESCRIPTION
#### From documentation:
This resource requires a PagerDuty user-level API key. This can be set as the user_token on the provider tag or as the PAGERDUTY_USER_TOKEN environment variable.

https://github.com/PagerDuty/terraform-provider-pagerduty/blob/master/pagerduty/config.go#L110

### Description of your changes

define user_token for terraform provider, need for `slack` integration, without it you got authorization error when create connection object

### How has this code been tested

I built binary and ran in my environment
