### PR TITLE
Fix CI: Rollback GO_REQUIRED_VERSION to 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_REQUIRED_VERSION ?= 1.20
+GO_REQUIRED_VERSION ?= 1.19
 GOLANGCILINT_VERSION ?= 1.50.0
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)


### PR DESCRIPTION
### Description of your changes

Set GO_REQUIRED_VERSION back to 1.19 since bumping it to 1.20 broke the CI workflow with

`build/makelib/golang.mk:93: *** "go version 1.19 is not supported. required version is 1.20".  Stop.`

Since this bump was not really necessary this PR reverts it.

Fixes #

I have:

- [ X] Read and followed Crossplane's [contribution process].
- [ X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Compared workflows before and after fix in forked repository.
