### PR TITLE
fix(eventhandler): add newEventHandler() as tjcontroller.Options

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	tjcontroller "github.com/upbound/upjet/pkg/controller"
+	"github.com/upbound/upjet/pkg/controller/handler"
 	"github.com/upbound/upjet/pkg/terraform"
 	"gopkg.in/alecthomas/kingpin.v2"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -90,6 +91,7 @@ func main() {
 		Provider:       config.GetProvider(),
 		SetupFn:        clients.TerraformSetupBuilder(*terraformVersion, *nativeProviderSource, *providerVersion),
 		WorkspaceStore: terraform.NewWorkspaceStore(log, terraform.WithDisableInit(len(*nativeProviderPath) != 0), terraform.WithProcessReportInterval(*pollInterval), terraform.WithFeatures(featureFlags)),
+		EventHandler:   handler.NewEventHandler(),
 	}
 
 	if *enableExternalSecretStores {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fix(eventhandler): add newEventHandler() as tjcontroller.Options


fix the following issue with new upjet version:

```
2023-08-03T14:57:52+02:00       INFO    Starting workers        {"controller": "managed/escalation.pagerduty.crossplane.io/v1alpha1, kind=policy", "worker count": 10}
E0803 14:57:57.720685   68417 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 900 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x10423eca0?, 0x1053fefe0})
        k8s.io/apimachinery@v0.27.3/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x1044cf540?})
        k8s.io/apimachinery@v0.27.3/pkg/util/runtime/runtime.go:49 +0x78
panic({0x10423eca0, 0x1053fefe0})
        runtime/panic.go:884 +0x204
github.com/upbound/upjet/pkg/controller/handler.(*EventHandler).setQueue(0x0, {0x1044f4ac0?, 0x1400004c200})
        github.com/upbound/upjet@v0.10.0-rc.0.0.20230802121849-caa74d2aebf2/pkg/controller/handler/eventhandler.go:89 +0x30
github.com/upbound/upjet/pkg/controller/handler.(*EventHandler).Create(0x0, {0x1044eb9c0, 0x14000c287c0}, {{0x1044feb00?, 0x14000c3a000?}}, {0x1044f4ac0, 0x1400004c200})
        github.com/upbound/upjet@v0.10.0-rc.0.0.20230802121849-caa74d2aebf2/pkg/controller/handler/eventhandler.go:97 +0x48
sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnAdd(0x14000466f00, {0x1044b26e0?, 0x14000c3a000})
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/source/event_handler.go:88 +0x1e4
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
        k8s.io/client-go@v0.27.3/tools/cache/controller.go:243
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        k8s.io/client-go@v0.27.3/tools/cache/shared_informer.go:973 +0x164
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:226 +0x40
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x14000ee0f28?, {0x1044d3180, 0x14000cc1f50}, 0x1, 0x14000666f60)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:227 +0x90
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:204 +0x80
k8s.io/apimachinery/pkg/util/wait.Until(...)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0x14000c70b40?)
        k8s.io/client-go@v0.27.3/tools/cache/shared_informer.go:967 +0x68
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/wait.go:72 +0x58
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/wait.go:70 +0x84
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1037508c0]

goroutine 900 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x1044cf540?})
        k8s.io/apimachinery@v0.27.3/pkg/util/runtime/runtime.go:56 +0xe4
panic({0x10423eca0, 0x1053fefe0})
        runtime/panic.go:884 +0x204
github.com/upbound/upjet/pkg/controller/handler.(*EventHandler).setQueue(0x0, {0x1044f4ac0?, 0x1400004c200})
        github.com/upbound/upjet@v0.10.0-rc.0.0.20230802121849-caa74d2aebf2/pkg/controller/handler/eventhandler.go:89 +0x30
github.com/upbound/upjet/pkg/controller/handler.(*EventHandler).Create(0x0, {0x1044eb9c0, 0x14000c287c0}, {{0x1044feb00?, 0x14000c3a000?}}, {0x1044f4ac0, 0x1400004c200})
        github.com/upbound/upjet@v0.10.0-rc.0.0.20230802121849-caa74d2aebf2/pkg/controller/handler/eventhandler.go:97 +0x48
sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnAdd(0x14000466f00, {0x1044b26e0?, 0x14000c3a000})
        sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/source/event_handler.go:88 +0x1e4
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
        k8s.io/client-go@v0.27.3/tools/cache/controller.go:243
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        k8s.io/client-go@v0.27.3/tools/cache/shared_informer.go:973 +0x164
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:226 +0x40
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x14000ee0f28?, {0x1044d3180, 0x14000cc1f50}, 0x1, 0x14000666f60)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:227 +0x90
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x3b9aca00, 0x0, 0x0?, 0x0?)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:204 +0x80
k8s.io/apimachinery/pkg/util/wait.Until(...)
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0x14000c70b40?)
        k8s.io/client-go@v0.27.3/tools/cache/shared_informer.go:967 +0x68
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/wait.go:72 +0x58
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        k8s.io/apimachinery@v0.27.3/pkg/util/wait/wait.go:70 +0x84
make: *** [run] Error 2
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
