### PR TITLE
fix(service-integration): write integration_key into connection details secret

### DIFF
--- a/config/service/config.go
+++ b/config/service/config.go
@@ -45,6 +45,14 @@ func Configure(p *config.Provider) {
 				Type: "Service",
 			},
 		}
+
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["integration_key"].(string); ok {
+				conn["integration_key"] = []byte(a)
+			}
+			return conn, nil
+		}
 	})
 
 }


### PR DESCRIPTION
### Description of your changes

This PR lets `integration.service.pagerduty.crossplane.io` write the `integrationKey` into the connection secret specified by `writeConnectionSecretToRef`. This is especially useful when a new api key is requested and should be consumed by objects that read it from a secret, such as e.g. [Grafana ContactPoints](https://marketplace.upbound.io/providers/grafana/provider-grafana/v0.8.0/resources/alerting.grafana.crossplane.io/ContactPoint/v1alpha1#doc:spec-forProvider-pagerduty-integrationKeySecretRef).

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Run provider and created an Integration with `writeConnectionSecretToRef` set to a secret, then checked the secret.
