### PR TITLE
fix business service create failure

### DIFF
--- a/config/cluster/business/config.go
+++ b/config/cluster/business/config.go
@@ -15,6 +15,14 @@ func Configure(p *config.Provider) {
 				TerraformName: "pagerduty_team",
 			},
 		}
+		if r.MetaResource != nil && len(r.MetaResource.Examples) > 0 {
+			if r.MetaResource.Examples[0].Dependencies == nil {
+				r.MetaResource.Examples[0].Dependencies = map[string]string{}
+			}
+			r.MetaResource.Examples[0].Dependencies["pagerduty_team.example"] = `{
+  "name": "Business Service Team"
+}`
+		}
 		r.ExternalName.GetExternalNameFn = c.GetExternalNameFromId
 		r.ExternalName.GetIDFn = c.GetFakeID
 		// Deprecated

--- a/config/cluster/common/common.go
+++ b/config/cluster/common/common.go
@@ -12,7 +12,9 @@ import (
 const (
 	ErrFmtNoAttribute    = `attribute not found: %s`
 	ErrFmtUnexpectedType = `unexpected type for attribute %s: Expecting a string`
-	fakeId               = `managed`
+	// pagerDutyIDShapedSentinel avoids empty-ID reads while keeping the value
+	// valid-shaped for PagerDuty APIs that reject arbitrary text before lookup.
+	pagerDutyIDShapedSentinel = `P000000`
 )
 
 func getStringFromParams(parameters map[string]interface{}, keys []string, separator rune) (string, error) {
@@ -45,7 +47,7 @@ func GetExternalNameFromId(tfstate map[string]any) (string, error) {
 
 func GetFakeID(_ context.Context, externalName string, _ map[string]any, _ map[string]any) (string, error) {
 	if externalName == "" {
-		return fakeId, nil
+		return pagerDutyIDShapedSentinel, nil
 	}
 	return externalName, nil
 }

--- a/config/cluster/common/common_test.go
+++ b/config/cluster/common/common_test.go
@@ -1,0 +1,34 @@
+package commmon
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetFakeID(t *testing.T) {
+	tests := map[string]struct {
+		externalName string
+		want         string
+	}{
+		"empty external name uses pagerduty-shaped sentinel": {
+			externalName: "",
+			want:         pagerDutyIDShapedSentinel,
+		},
+		"existing external name is unchanged": {
+			externalName: "PABC123",
+			want:         "PABC123",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetFakeID(context.Background(), tt.externalName, nil, nil)
+			if err != nil {
+				t.Fatalf("GetFakeID returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("GetFakeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/namespaced/business/config.go
+++ b/config/namespaced/business/config.go
@@ -15,6 +15,14 @@ func Configure(p *config.Provider) {
 				TerraformName: "pagerduty_team",
 			},
 		}
+		if r.MetaResource != nil && len(r.MetaResource.Examples) > 0 {
+			if r.MetaResource.Examples[0].Dependencies == nil {
+				r.MetaResource.Examples[0].Dependencies = map[string]string{}
+			}
+			r.MetaResource.Examples[0].Dependencies["pagerduty_team.example"] = `{
+  "name": "Business Service Team"
+}`
+		}
 		r.ExternalName.GetExternalNameFn = c.GetExternalNameFromId
 		r.ExternalName.GetIDFn = c.GetFakeID
 		// Deprecated

--- a/config/namespaced/common/common.go
+++ b/config/namespaced/common/common.go
@@ -12,7 +12,9 @@ import (
 const (
 	ErrFmtNoAttribute    = `attribute not found: %s`
 	ErrFmtUnexpectedType = `unexpected type for attribute %s: Expecting a string`
-	fakeId               = `managed`
+	// pagerDutyIDShapedSentinel avoids empty-ID reads while keeping the value
+	// valid-shaped for PagerDuty APIs that reject arbitrary text before lookup.
+	pagerDutyIDShapedSentinel = `P000000`
 )
 
 func getStringFromParams(parameters map[string]interface{}, keys []string, separator rune) (string, error) {
@@ -45,7 +47,7 @@ func GetExternalNameFromId(tfstate map[string]any) (string, error) {
 
 func GetFakeID(_ context.Context, externalName string, _ map[string]any, _ map[string]any) (string, error) {
 	if externalName == "" {
-		return fakeId, nil
+		return pagerDutyIDShapedSentinel, nil
 	}
 	return externalName, nil
 }

--- a/config/namespaced/common/common_test.go
+++ b/config/namespaced/common/common_test.go
@@ -1,0 +1,34 @@
+package commmon
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetFakeID(t *testing.T) {
+	tests := map[string]struct {
+		externalName string
+		want         string
+	}{
+		"empty external name uses pagerduty-shaped sentinel": {
+			externalName: "",
+			want:         pagerDutyIDShapedSentinel,
+		},
+		"existing external name is unchanged": {
+			externalName: "PABC123",
+			want:         "PABC123",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetFakeID(context.Background(), tt.externalName, nil, nil)
+			if err != nil {
+				t.Fatalf("GetFakeID returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("GetFakeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/provider.go
+++ b/config/provider.go
@@ -7,6 +7,7 @@ package config
 import (
 	// Note(turkenh): we are importing this to embed provider schema document
 	_ "embed"
+	"os"
 
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
 
@@ -52,8 +53,9 @@ import (
 )
 
 const (
-	resourcePrefix = "pagerduty"
-	modulePath     = "github.com/crossplane-contrib/provider-pagerduty"
+	resourcePrefix                  = "pagerduty"
+	modulePath                      = "github.com/crossplane-contrib/provider-pagerduty"
+	defaultManagedResourceNamespace = "crossplane-system"
 )
 
 //go:embed schema.json
@@ -62,6 +64,16 @@ var providerSchema string
 //go:embed provider-metadata.yaml
 var providerMetadata string
 
+func exampleManifestConfiguration() ujconfig.ExampleManifestConfiguration {
+	namespace := os.Getenv("CROSSPLANE_NAMESPACE")
+	if namespace == "" {
+		namespace = defaultManagedResourceNamespace
+	}
+	return ujconfig.ExampleManifestConfiguration{
+		ManagedResourceNamespace: namespace,
+	}
+}
+
 // GetProvider returns provider configuration
 func GetProvider() *ujconfig.Provider {
 	pc := ujconfig.NewProvider([]byte(providerSchema), resourcePrefix, modulePath, []byte(providerMetadata),
@@ -69,6 +81,7 @@ func GetProvider() *ujconfig.Provider {
 		ujconfig.WithShortName("pagerduty"),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithRootGroup("pagerduty.crossplane.io"),
+		ujconfig.WithExampleManifestConfiguration(exampleManifestConfiguration()),
 		ujconfig.WithDefaultResourceOptions(
 			ExternalNameConfigurations(),
 		))
@@ -109,6 +122,7 @@ func GetProviderNamespaced() *ujconfig.Provider {
 		ujconfig.WithShortName("pagerduty"),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithRootGroup("pagerduty.m.crossplane.io"),
+		ujconfig.WithExampleManifestConfiguration(exampleManifestConfiguration()),
 		ujconfig.WithDefaultResourceOptions(
 			ExternalNameConfigurations(),
 		))

--- a/examples-generated/cluster/automation/v1alpha1/runner.yaml
+++ b/examples-generated/cluster/automation/v1alpha1/runner.yaml
@@ -13,6 +13,6 @@ spec:
     runbookApiKeySecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     runbookBaseUri: rdcat.stg
     runnerType: runbook

--- a/examples-generated/cluster/automation/v1alpha1/runnerteamassociation.yaml
+++ b/examples-generated/cluster/automation/v1alpha1/runnerteamassociation.yaml
@@ -32,7 +32,7 @@ spec:
     runbookApiKeySecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     runbookBaseUri: cat-cat
     runnerType: runbook
 

--- a/examples-generated/cluster/business/v1alpha1/service.yaml
+++ b/examples-generated/cluster/business/v1alpha1/service.yaml
@@ -14,3 +14,17 @@ spec:
     teamSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+
+---
+
+apiVersion: team.pagerduty.crossplane.io/v1alpha1
+kind: Team
+metadata:
+  annotations:
+    meta.upbound.io/example-id: business/v1alpha1/service
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    name: Business Service Team

--- a/examples-generated/cluster/extensions/v1alpha1/extension.yaml
+++ b/examples-generated/cluster/extensions/v1alpha1/extension.yaml
@@ -14,7 +14,7 @@ spec:
     endpointUrlSecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     extensionObjectsRefs:
     - name: example
     extensionSchema: ${data.pagerduty_extension_schema.webhook.id}

--- a/examples-generated/cluster/extensions/v1alpha1/servicenow.yaml
+++ b/examples-generated/cluster/extensions/v1alpha1/servicenow.yaml
@@ -16,7 +16,7 @@ spec:
     snowPasswordSecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     snowUser: meeps
     syncOptions: manual_sync
     target: https://foo.servicenow.com/webhook_foo

--- a/examples-generated/namespaced/addon/v1alpha1/addon.yaml
+++ b/examples-generated/namespaced/addon/v1alpha1/addon.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Internal Status Page

--- a/examples-generated/namespaced/alert/v1alpha1/groupingsetting.yaml
+++ b/examples-generated/namespaced/alert/v1alpha1/groupingsetting.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: basic_settings
   name: basic-settings
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     config:
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: basic
   name: basic
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     escalationPolicySelector:

--- a/examples-generated/namespaced/automation/v1alpha1/action.yaml
+++ b/examples-generated/namespaced/automation/v1alpha1/action.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:

--- a/examples-generated/namespaced/automation/v1alpha1/actionserviceassociation.yaml
+++ b/examples-generated/namespaced/automation/v1alpha1/actionserviceassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionIdSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:
@@ -45,7 +45,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -66,7 +66,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -90,7 +90,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/automation/v1alpha1/actionteamassociation.yaml
+++ b/examples-generated/namespaced/automation/v1alpha1/actionteamassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionIdSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:
@@ -45,7 +45,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: All engineering

--- a/examples-generated/namespaced/automation/v1alpha1/runner.yaml
+++ b/examples-generated/namespaced/automation/v1alpha1/runner.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Description of the Runner created via TF

--- a/examples-generated/namespaced/automation/v1alpha1/runnerteamassociation.yaml
+++ b/examples-generated/namespaced/automation/v1alpha1/runnerteamassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_runner_ent_eng_assoc
   name: pa-runner-ent-eng-assoc
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     runnerSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_runbook_runner
   name: pa-runbook-runner
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Description of the Runner created via TF
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: team_ent_eng
   name: team-ent-eng
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Enterprise engineering

--- a/examples-generated/namespaced/business/v1alpha1/service.yaml
+++ b/examples-generated/namespaced/business/v1alpha1/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: A very descriptive description of this business service
@@ -15,3 +15,18 @@ spec:
     teamSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+
+---
+
+apiVersion: team.pagerduty.m.crossplane.io/v1alpha1
+kind: Team
+metadata:
+  annotations:
+    meta.upbound.io/example-id: business/v1alpha1/service
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+  namespace: crossplane-system
+spec:
+  forProvider:
+    name: Business Service Team

--- a/examples-generated/namespaced/business/v1alpha1/servicesubscriber.yaml
+++ b/examples-generated/namespaced/business/v1alpha1/servicesubscriber.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: team_example
   name: team-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     businessServiceIdSelector:
@@ -27,7 +27,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: A very descriptive description of this business service
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engteam
   name: engteam
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering
@@ -62,7 +62,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/escalation/v1alpha1/policy.yaml
+++ b/examples-generated/namespaced/escalation/v1alpha1/policy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -31,7 +31,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: All engineering
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/event/v1alpha1/orchestration.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_monitor
   name: my-monitor
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Send events to a pair of services
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engineering
   name: engineering
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationglobal.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationglobal.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: global
   name: global
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -62,7 +62,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -80,7 +80,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationglobalcachevariable.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationglobalcachevariable.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: recent_host
   name: recent-host
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition:
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -48,7 +48,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: global
   name: global
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -79,7 +79,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: host_ignore_list
   name: host-ignore-list
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     configuration:
@@ -99,7 +99,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationintegration.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationintegration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: integration
   name: integration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     eventOrchestrationSelector:
@@ -24,7 +24,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -42,7 +42,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationrouter.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationrouter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: router
   name: router
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationservice.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationservice.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: www
   name: www
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -91,7 +91,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -112,7 +112,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: cs_impact
   name: cs-impact
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -129,7 +129,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -150,7 +150,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engineering
   name: engineering
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering
@@ -165,7 +165,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     role: manager
@@ -186,7 +186,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationservicecachevariable.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationservicecachevariable.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: num_db_triggers
   name: num-db-triggers
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition:
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: db_ep
   name: db-ep
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Escalation Policy
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -85,7 +85,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: svc
   name: svc
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -106,7 +106,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team
@@ -121,7 +121,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: user_1
   name: user-1
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/event/v1alpha1/orchestrationunrouted.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/orchestrationunrouted.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: unrouted
   name: unrouted
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:

--- a/examples-generated/namespaced/event/v1alpha1/rule.yaml
+++ b/examples-generated/namespaced/event/v1alpha1/rule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: second
   name: second
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionJson: |-

--- a/examples-generated/namespaced/extensions/v1alpha1/extension.yaml
+++ b/examples-generated/namespaced/extensions/v1alpha1/extension.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: slack
   name: slack
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     config: "{\n\t\"restrict\": \"any\",\n\t\"notify_types\": {\n\t\t\t\"resolve\":
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -51,7 +51,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -71,7 +71,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: howard.james@example.domain

--- a/examples-generated/namespaced/extensions/v1alpha1/servicenow.yaml
+++ b/examples-generated/namespaced/extensions/v1alpha1/servicenow.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: snow
   name: snow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     extensionObjects:
@@ -32,7 +32,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -53,7 +53,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -73,7 +73,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: howard.james@example.domain

--- a/examples-generated/namespaced/incident/v1alpha1/customfield.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/customfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: cs_impact
   name: cs-impact
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples-generated/namespaced/incident/v1alpha1/customfieldoption.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/customfieldoption.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: dev_environment
   name: dev-environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: sre_environment
   name: sre-environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples-generated/namespaced/incident/v1alpha1/incidenttype.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/incidenttype.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Internal incidents not facing customer

--- a/examples-generated/namespaced/incident/v1alpha1/typecustomfield.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/typecustomfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: alarm_time
   name: alarm-time
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: integer

--- a/examples-generated/namespaced/incident/v1alpha1/workflow.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/workflow.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_first_workflow
   name: my-first-workflow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: This Incident Workflow is an example

--- a/examples-generated/namespaced/incident/v1alpha1/workflowtrigger.yaml
+++ b/examples-generated/namespaced/incident/v1alpha1/workflowtrigger.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: automatic_trigger
   name: automatic-trigger
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition: incident.priority matches 'P1'
@@ -28,7 +28,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_first_workflow
   name: my-first-workflow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: This Incident Workflow is an example

--- a/examples-generated/namespaced/jira/v1alpha1/cloudaccountmappingrule.yaml
+++ b/examples-generated/namespaced/jira/v1alpha1/cloudaccountmappingrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     accountMapping: PLBP09X
@@ -22,7 +22,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     escalationPolicySelector:
@@ -40,7 +40,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/maintenance/v1alpha1/window.yaml
+++ b/examples-generated/namespaced/maintenance/v1alpha1/window.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     endTime: "2015-11-09T22:00:00-05:00"

--- a/examples-generated/namespaced/pagerduty/v1alpha1/enablement.yaml
+++ b/examples-generated/namespaced/pagerduty/v1alpha1/enablement.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     enabled: true

--- a/examples-generated/namespaced/response/v1alpha1/play.yaml
+++ b/examples-generated/namespaced/response/v1alpha1/play.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     from: 125.greenholt.earline@graham.name
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/ruleset/v1alpha1/rule.yaml
+++ b/examples-generated/namespaced/ruleset/v1alpha1/rule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actions:
@@ -64,7 +64,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Primary Ruleset
@@ -83,7 +83,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering (Seattle)

--- a/examples-generated/namespaced/ruleset/v1alpha1/ruleset.yaml
+++ b/examples-generated/namespaced/ruleset/v1alpha1/ruleset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Primary Ruleset
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering (Seattle)

--- a/examples-generated/namespaced/schedule/v1alpha1/schedule.yaml
+++ b/examples-generated/namespaced/schedule/v1alpha1/schedule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     layer:
@@ -35,7 +35,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: A Team
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/service/v1alpha1/customfield.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/customfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: environment
   name: environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples-generated/namespaced/service/v1alpha1/customfieldvalue.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/customfieldvalue.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     customFields:
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: environment
   name: environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -69,7 +69,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: is_critical
   name: is-critical
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: boolean
@@ -88,7 +88,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: region
   name: region
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -107,7 +107,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: regions
   name: regions
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples-generated/namespaced/service/v1alpha1/dependency.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/dependency.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dependency:

--- a/examples-generated/namespaced/service/v1alpha1/eventrule.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/eventrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actions:
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600

--- a/examples-generated/namespaced/service/v1alpha1/integration.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/integration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Generic API Service Integration
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -46,7 +46,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -66,7 +66,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/service/v1alpha1/service.yaml
+++ b/examples-generated/namespaced/service/v1alpha1/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -51,7 +51,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/slack/v1alpha1/connection.yaml
+++ b/examples-generated/namespaced/slack/v1alpha1/connection.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     channelId: C02CABCDAC9
@@ -42,7 +42,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Team Foo

--- a/examples-generated/namespaced/tag/v1alpha1/assignment.yaml
+++ b/examples-generated/namespaced/tag/v1alpha1/assignment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     entityId: ${pagerduty_team.engteam.id}
@@ -23,7 +23,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     label: API
@@ -38,7 +38,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engteam
   name: engteam
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering

--- a/examples-generated/namespaced/tag/v1alpha1/tag.yaml
+++ b/examples-generated/namespaced/tag/v1alpha1/tag.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     label: Product

--- a/examples-generated/namespaced/team/v1alpha1/membership.yaml
+++ b/examples-generated/namespaced/team/v1alpha1/membership.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     role: manager
@@ -27,7 +27,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: foo
@@ -43,7 +43,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: foo@bar.com

--- a/examples-generated/namespaced/team/v1alpha1/team.yaml
+++ b/examples-generated/namespaced/team/v1alpha1/team.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: parent
   name: parent
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Product and Engineering

--- a/examples-generated/namespaced/user/v1alpha1/contactmethod.yaml
+++ b/examples-generated/namespaced/user/v1alpha1/contactmethod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: email
   name: email
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: foo@bar.com
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/user/v1alpha1/handoffnotificationrule.yaml
+++ b/examples-generated/namespaced/user/v1alpha1/handoffnotificationrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example-oncall-offcall
   name: example-oncall-offcall
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     contactMethod:
@@ -28,7 +28,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@foo.test
@@ -44,7 +44,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: phone
   name: phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"

--- a/examples-generated/namespaced/user/v1alpha1/notificationrule.yaml
+++ b/examples-generated/namespaced/user/v1alpha1/notificationrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: high_urgency_phone
   name: high-urgency-phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     startDelayInMinutes: 1
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name
@@ -41,7 +41,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: email
   name: email
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: foo@bar.com
@@ -61,7 +61,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: phone
   name: phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"
@@ -82,7 +82,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: sms
   name: sms
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"

--- a/examples-generated/namespaced/user/v1alpha1/user.yaml
+++ b/examples-generated/namespaced/user/v1alpha1/user.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples-generated/namespaced/webhook/v1alpha1/subscription.yaml
+++ b/examples-generated/namespaced/webhook/v1alpha1/subscription.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     active: true

--- a/examples/cluster/automation/v1alpha1/runner.yaml
+++ b/examples/cluster/automation/v1alpha1/runner.yaml
@@ -13,6 +13,6 @@ spec:
     runbookApiKeySecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     runbookBaseUri: rdcat.stg
     runnerType: runbook

--- a/examples/cluster/automation/v1alpha1/runnerteamassociation.yaml
+++ b/examples/cluster/automation/v1alpha1/runnerteamassociation.yaml
@@ -32,7 +32,7 @@ spec:
     runbookApiKeySecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     runbookBaseUri: cat-cat
     runnerType: runbook
 

--- a/examples/cluster/business/v1alpha1/service.yaml
+++ b/examples/cluster/business/v1alpha1/service.yaml
@@ -14,3 +14,17 @@ spec:
     teamSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+
+---
+
+apiVersion: team.pagerduty.crossplane.io/v1alpha1
+kind: Team
+metadata:
+  annotations:
+    meta.upbound.io/example-id: business/v1alpha1/service
+  labels:
+    testing.upbound.io/example-name: example
+  name: business-service-team
+spec:
+  forProvider:
+    name: Business Service Example Team

--- a/examples/cluster/business/v1alpha1/service.yaml
+++ b/examples/cluster/business/v1alpha1/service.yaml
@@ -24,7 +24,7 @@ metadata:
     meta.upbound.io/example-id: business/v1alpha1/service
   labels:
     testing.upbound.io/example-name: example
-  name: business-service-team
+  name: example
 spec:
   forProvider:
-    name: Business Service Example Team
+    name: Business Service Team

--- a/examples/cluster/extensions/v1alpha1/extension.yaml
+++ b/examples/cluster/extensions/v1alpha1/extension.yaml
@@ -14,7 +14,7 @@ spec:
     endpointUrlSecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     extensionObjectsRefs:
     - name: example
     extensionSchema: ${data.pagerduty_extension_schema.webhook.id}

--- a/examples/cluster/extensions/v1alpha1/servicenow.yaml
+++ b/examples/cluster/extensions/v1alpha1/servicenow.yaml
@@ -16,7 +16,7 @@ spec:
     snowPasswordSecretRef:
       key: example-key
       name: example-secret
-      namespace: upbound-system
+      namespace: crossplane-system
     snowUser: meeps
     syncOptions: manual_sync
     target: https://foo.servicenow.com/webhook_foo

--- a/examples/namespaced/addon/v1alpha1/addon.yaml
+++ b/examples/namespaced/addon/v1alpha1/addon.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Internal Status Page

--- a/examples/namespaced/alert/v1alpha1/groupingsetting.yaml
+++ b/examples/namespaced/alert/v1alpha1/groupingsetting.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: basic_settings
   name: basic-settings
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     config:
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: basic
   name: basic
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     escalationPolicySelector:

--- a/examples/namespaced/automation/v1alpha1/action.yaml
+++ b/examples/namespaced/automation/v1alpha1/action.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:

--- a/examples/namespaced/automation/v1alpha1/actionserviceassociation.yaml
+++ b/examples/namespaced/automation/v1alpha1/actionserviceassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionIdSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:
@@ -45,7 +45,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -66,7 +66,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -90,7 +90,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/automation/v1alpha1/actionteamassociation.yaml
+++ b/examples/namespaced/automation/v1alpha1/actionteamassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionIdSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_action_example
   name: pa-action-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionDataReference:
@@ -45,7 +45,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: All engineering

--- a/examples/namespaced/automation/v1alpha1/runner.yaml
+++ b/examples/namespaced/automation/v1alpha1/runner.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Description of the Runner created via TF

--- a/examples/namespaced/automation/v1alpha1/runnerteamassociation.yaml
+++ b/examples/namespaced/automation/v1alpha1/runnerteamassociation.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_runner_ent_eng_assoc
   name: pa-runner-ent-eng-assoc
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     runnerSelector:
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: pa_runbook_runner
   name: pa-runbook-runner
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Description of the Runner created via TF
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: team_ent_eng
   name: team-ent-eng
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Enterprise engineering

--- a/examples/namespaced/business/v1alpha1/service.yaml
+++ b/examples/namespaced/business/v1alpha1/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: A very descriptive description of this business service
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: business-service-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Business Service Example Team

--- a/examples/namespaced/business/v1alpha1/service.yaml
+++ b/examples/namespaced/business/v1alpha1/service.yaml
@@ -15,3 +15,18 @@ spec:
     teamSelector:
       matchLabels:
         testing.upbound.io/example-name: example
+
+---
+
+apiVersion: team.pagerduty.m.crossplane.io/v1alpha1
+kind: Team
+metadata:
+  annotations:
+    meta.upbound.io/example-id: business/v1alpha1/service
+  labels:
+    testing.upbound.io/example-name: example
+  name: business-service-team
+  namespace: upbound-system
+spec:
+  forProvider:
+    name: Business Service Example Team

--- a/examples/namespaced/business/v1alpha1/service.yaml
+++ b/examples/namespaced/business/v1alpha1/service.yaml
@@ -25,8 +25,8 @@ metadata:
     meta.upbound.io/example-id: business/v1alpha1/service
   labels:
     testing.upbound.io/example-name: example
-  name: business-service-team
+  name: example
   namespace: crossplane-system
 spec:
   forProvider:
-    name: Business Service Example Team
+    name: Business Service Team

--- a/examples/namespaced/business/v1alpha1/servicesubscriber.yaml
+++ b/examples/namespaced/business/v1alpha1/servicesubscriber.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: team_example
   name: team-example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     businessServiceIdSelector:
@@ -27,7 +27,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: A very descriptive description of this business service
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engteam
   name: engteam
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering
@@ -62,7 +62,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/escalation/v1alpha1/policy.yaml
+++ b/examples/namespaced/escalation/v1alpha1/policy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -31,7 +31,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: All engineering
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/event/v1alpha1/orchestration.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_monitor
   name: my-monitor
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Send events to a pair of services
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engineering
   name: engineering
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering

--- a/examples/namespaced/event/v1alpha1/orchestrationglobal.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationglobal.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: global
   name: global
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -62,7 +62,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -80,7 +80,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples/namespaced/event/v1alpha1/orchestrationglobalcachevariable.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationglobalcachevariable.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: recent_host
   name: recent-host
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition:
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -48,7 +48,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: global
   name: global
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -79,7 +79,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: host_ignore_list
   name: host-ignore-list
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     configuration:
@@ -99,7 +99,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples/namespaced/event/v1alpha1/orchestrationintegration.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationintegration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: integration
   name: integration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     eventOrchestrationSelector:
@@ -24,7 +24,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Example Orchestration
@@ -42,7 +42,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team

--- a/examples/namespaced/event/v1alpha1/orchestrationrouter.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationrouter.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: router
   name: router
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:

--- a/examples/namespaced/event/v1alpha1/orchestrationservice.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationservice.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: www
   name: www
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -91,7 +91,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -112,7 +112,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: cs_impact
   name: cs-impact
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -129,7 +129,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -150,7 +150,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engineering
   name: engineering
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering
@@ -165,7 +165,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     role: manager
@@ -186,7 +186,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/event/v1alpha1/orchestrationservicecachevariable.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationservicecachevariable.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: num_db_triggers
   name: num-db-triggers
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition:
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: db_ep
   name: db-ep
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Escalation Policy
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: event_orchestration
   name: event-orchestration
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:
@@ -85,7 +85,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: svc
   name: svc
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -106,7 +106,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: database_team
   name: database-team
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Database Team
@@ -121,7 +121,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: user_1
   name: user-1
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/event/v1alpha1/orchestrationunrouted.yaml
+++ b/examples/namespaced/event/v1alpha1/orchestrationunrouted.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: unrouted
   name: unrouted
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     catchAll:

--- a/examples/namespaced/event/v1alpha1/rule.yaml
+++ b/examples/namespaced/event/v1alpha1/rule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: second
   name: second
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actionJson: |-

--- a/examples/namespaced/extensions/v1alpha1/extension.yaml
+++ b/examples/namespaced/extensions/v1alpha1/extension.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: slack
   name: slack
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     config: "{\n\t\"restrict\": \"any\",\n\t\"notify_types\": {\n\t\t\t\"resolve\":
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -51,7 +51,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -71,7 +71,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: howard.james@example.domain

--- a/examples/namespaced/extensions/v1alpha1/servicenow.yaml
+++ b/examples/namespaced/extensions/v1alpha1/servicenow.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: snow
   name: snow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     extensionObjects:
@@ -32,7 +32,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -53,7 +53,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -73,7 +73,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: howard.james@example.domain

--- a/examples/namespaced/incident/v1alpha1/customfield.yaml
+++ b/examples/namespaced/incident/v1alpha1/customfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: cs_impact
   name: cs-impact
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples/namespaced/incident/v1alpha1/customfieldoption.yaml
+++ b/examples/namespaced/incident/v1alpha1/customfieldoption.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: dev_environment
   name: dev-environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: sre_environment
   name: sre-environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples/namespaced/incident/v1alpha1/incidenttype.yaml
+++ b/examples/namespaced/incident/v1alpha1/incidenttype.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Internal incidents not facing customer

--- a/examples/namespaced/incident/v1alpha1/typecustomfield.yaml
+++ b/examples/namespaced/incident/v1alpha1/typecustomfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: alarm_time
   name: alarm-time
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: integer

--- a/examples/namespaced/incident/v1alpha1/workflow.yaml
+++ b/examples/namespaced/incident/v1alpha1/workflow.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_first_workflow
   name: my-first-workflow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: This Incident Workflow is an example

--- a/examples/namespaced/incident/v1alpha1/workflowtrigger.yaml
+++ b/examples/namespaced/incident/v1alpha1/workflowtrigger.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: automatic_trigger
   name: automatic-trigger
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     condition: incident.priority matches 'P1'
@@ -28,7 +28,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: my_first_workflow
   name: my-first-workflow
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: This Incident Workflow is an example

--- a/examples/namespaced/jira/v1alpha1/cloudaccountmappingrule.yaml
+++ b/examples/namespaced/jira/v1alpha1/cloudaccountmappingrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     accountMapping: PLBP09X
@@ -22,7 +22,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     escalationPolicySelector:
@@ -40,7 +40,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/maintenance/v1alpha1/window.yaml
+++ b/examples/namespaced/maintenance/v1alpha1/window.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     endTime: "2015-11-09T22:00:00-05:00"

--- a/examples/namespaced/pagerduty/v1alpha1/enablement.yaml
+++ b/examples/namespaced/pagerduty/v1alpha1/enablement.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     enabled: true

--- a/examples/namespaced/response/v1alpha1/play.yaml
+++ b/examples/namespaced/response/v1alpha1/play.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     from: 125.greenholt.earline@graham.name
@@ -29,7 +29,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/ruleset/v1alpha1/rule.yaml
+++ b/examples/namespaced/ruleset/v1alpha1/rule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actions:
@@ -64,7 +64,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Primary Ruleset
@@ -83,7 +83,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering (Seattle)

--- a/examples/namespaced/ruleset/v1alpha1/ruleset.yaml
+++ b/examples/namespaced/ruleset/v1alpha1/ruleset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Primary Ruleset
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering (Seattle)

--- a/examples/namespaced/schedule/v1alpha1/schedule.yaml
+++ b/examples/namespaced/schedule/v1alpha1/schedule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     layer:
@@ -35,7 +35,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: A Team
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/service/v1alpha1/customfield.yaml
+++ b/examples/namespaced/service/v1alpha1/customfield.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: environment
   name: environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples/namespaced/service/v1alpha1/customfieldvalue.yaml
+++ b/examples/namespaced/service/v1alpha1/customfieldvalue.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     customFields:
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -50,7 +50,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: environment
   name: environment
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -69,7 +69,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: is_critical
   name: is-critical
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: boolean
@@ -88,7 +88,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: region
   name: region
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string
@@ -107,7 +107,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: regions
   name: regions
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dataType: string

--- a/examples/namespaced/service/v1alpha1/dependency.yaml
+++ b/examples/namespaced/service/v1alpha1/dependency.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     dependency:

--- a/examples/namespaced/service/v1alpha1/eventrule.yaml
+++ b/examples/namespaced/service/v1alpha1/eventrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     actions:
@@ -47,7 +47,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600

--- a/examples/namespaced/service/v1alpha1/integration.yaml
+++ b/examples/namespaced/service/v1alpha1/integration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Generic API Service Integration
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -46,7 +46,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -66,7 +66,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/service/v1alpha1/service.yaml
+++ b/examples/namespaced/service/v1alpha1/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     acknowledgementTimeout: 600
@@ -30,7 +30,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering Escalation Policy
@@ -51,7 +51,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/slack/v1alpha1/connection.yaml
+++ b/examples/namespaced/slack/v1alpha1/connection.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     channelId: C02CABCDAC9
@@ -42,7 +42,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Team Foo

--- a/examples/namespaced/tag/v1alpha1/assignment.yaml
+++ b/examples/namespaced/tag/v1alpha1/assignment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     entityId: ${pagerduty_team.engteam.id}
@@ -23,7 +23,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     label: API
@@ -38,7 +38,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: engteam
   name: engteam
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     name: Engineering

--- a/examples/namespaced/tag/v1alpha1/tag.yaml
+++ b/examples/namespaced/tag/v1alpha1/tag.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     label: Product

--- a/examples/namespaced/team/v1alpha1/membership.yaml
+++ b/examples/namespaced/team/v1alpha1/membership.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     role: manager
@@ -27,7 +27,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: foo
@@ -43,7 +43,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: foo@bar.com

--- a/examples/namespaced/team/v1alpha1/team.yaml
+++ b/examples/namespaced/team/v1alpha1/team.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: parent
   name: parent
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     description: Product and Engineering

--- a/examples/namespaced/user/v1alpha1/contactmethod.yaml
+++ b/examples/namespaced/user/v1alpha1/contactmethod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: email
   name: email
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: foo@bar.com
@@ -26,7 +26,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/user/v1alpha1/handoffnotificationrule.yaml
+++ b/examples/namespaced/user/v1alpha1/handoffnotificationrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example-oncall-offcall
   name: example-oncall-offcall
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     contactMethod:
@@ -28,7 +28,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@foo.test
@@ -44,7 +44,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: phone
   name: phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"

--- a/examples/namespaced/user/v1alpha1/notificationrule.yaml
+++ b/examples/namespaced/user/v1alpha1/notificationrule.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: high_urgency_phone
   name: high-urgency-phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     startDelayInMinutes: 1
@@ -25,7 +25,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name
@@ -41,7 +41,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: email
   name: email
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: foo@bar.com
@@ -61,7 +61,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: phone
   name: phone
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"
@@ -82,7 +82,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: sms
   name: sms
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     address: "2025550199"

--- a/examples/namespaced/user/v1alpha1/user.yaml
+++ b/examples/namespaced/user/v1alpha1/user.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: example
   name: example
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     email: 125.greenholt.earline@graham.name

--- a/examples/namespaced/webhook/v1alpha1/subscription.yaml
+++ b/examples/namespaced/webhook/v1alpha1/subscription.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     testing.upbound.io/example-name: foo
   name: foo
-  namespace: upbound-system
+  namespace: crossplane-system
 spec:
   forProvider:
     active: true


### PR DESCRIPTION
### Description of changes

Fixes: #129 

In addition to adjusting the fakeID used, I have adjusted the namespaces for all the namespaced resources from upbound-system to crossplane-system. This matches the namespace actually created by the tests. Before making this change the namespaced e2e tests for Business Services would fail due to trying to create into a non-existent namespace. I think this matches the direction of the crossplane tooling as well and upbound-system was just left over after a recent switch.

I also had to adjust the business service examples to create a team to reference since it was failing because one matching the selector did not exist.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have ran `make reviewable test`.
I also ran:
- `UPTEST_EXAMPLE_LIST=examples/cluster/business/v1alpha1/service.yaml make e2e`
- `UPTEST_EXAMPLE_LIST=examples/namespaced/team/v1alpha1/service.yaml make e2e`
- `UPTEST_EXAMPLE_LIST=examples/cluster/team/v1alpha1/team.yaml make e2e`
- `UPTEST_EXAMPLE_LIST=examples/namespaced/team/v1alpha1/team.yaml make e2e`

[contribution process]: https://git.io/fj2m9
